### PR TITLE
Fix ceph module's cmake rule error and wrong usage of list in FindWBclient.cmake file

### DIFF
--- a/src/FSAL/FSAL_CEPH/CMakeLists.txt
+++ b/src/FSAL/FSAL_CEPH/CMakeLists.txt
@@ -2,16 +2,6 @@ add_definitions(
   -D_FILE_OFFSET_BITS=64
 )
 
-########### next target ###############
-
-# Build source locations and parameters
-IF(CEPH_PREFIX)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I${CEPH_PREFIX}/include")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -L${CEPH_PREFIX}/lib")
-ELSE()
-  message(WARNING "no ceph prefix")
-ENDIF()
-
 SET(fsalceph_LIB_SRCS
    main.c
    export.c

--- a/src/cmake/modules/FindWBclient.cmake
+++ b/src/cmake/modules/FindWBclient.cmake
@@ -19,7 +19,7 @@ find_path(WBCLIENT_INCLUDE_DIR wbclient.h
   /usr/local/include
   )
 
-set(CMAKE_REQUIRED_INCLUDES ${WBCLIENT_INCLUDE_DIR})
+LIST(APPEND CMAKE_REQUIRED_INCLUDES ${WBCLIENT_INCLUDE_DIR})
 
 find_library(WBCLIENT_LIBRARIES NAMES wbclient
   PATHS
@@ -37,7 +37,7 @@ check_library_exists(
 check_include_files("stdint.h;stdbool.h;wbclient.h" WBCLIENT_H)
 
 # XXX this check is doing the heavy lifting
-set(CMAKE_REQUIRED_LIBRARIES ${WBCLIENT_LIBRARIES})
+LIST(APPEND CMAKE_REQUIRED_LIBRARIES ${WBCLIENT_LIBRARIES})
 if(WBCLIENT_H)
   check_c_source_compiles("
 /* do the enum */


### PR DESCRIPTION
- ceph lib path is set during the global cmake process, so we needn't set it in the cmake file of ceph module, which introduced a complie warning, clean up it.
- CMAKE_REQUIRED_INCLUDES and CMAKE_REQUIRED_LIBRARIES are list, so shouldn't use set command to modify them (in FindWBclient.cmake). Fix it.
